### PR TITLE
Refactor tuple handling in DeleteRecording

### DIFF
--- a/Shared/Recording.cs
+++ b/Shared/Recording.cs
@@ -1188,7 +1188,9 @@ namespace RecM
         public static async Task<bool> DeleteRecording(string name, string model)
         {
             // Latent event that sends little increments of data to the server
-            (bool success, string msg) = await EventDispatcher.Get<Tuple<bool, string>>("RecM:deleteRecording:Server", name, model);
+            var response = await EventDispatcher.Get<Tuple<bool, string>>("RecM:deleteRecording:Server", name, model);
+            var success = response.Item1;
+            var msg = response.Item2;
             if (!success)
             {
                 msg.Error(true);


### PR DESCRIPTION
## Summary
- avoid tuple deconstruction syntax when retrieving the delete recording response

## Testing
- `dotnet build RecM.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfe0b471483269092080edc019eaa