### PR TITLE
Adjust recording retrieval handling

### DIFF
--- a/Client/Menus/RecordingManager.cs
+++ b/Client/Menus/RecordingManager.cs
@@ -324,8 +324,9 @@ namespace RecM.Client.Menus
                 savedRecordingsMenuItem.Description = "Loading...";
 
                 // Get the recordings
-                (List<string> vanilla, Dictionary<string, RecordingListing> custom) = await Recording.GetRecordings();
-                custom ??= [];
+                var recordings = await Recording.GetRecordings();
+                var vanilla = recordings.Item1;
+                var custom = recordings.Item2 ?? new Dictionary<string, RecordingListing>();
 
                 savedRecordingsMenuItem.Enabled = true;
                 savedRecordingsMenuItem.Description = "This menu contains all the saved recordings.";


### PR DESCRIPTION
## Summary
- retrieve recordings without tuple deconstruction to avoid nullable tuple issues
- ensure custom recordings dictionary always non-null when menu opens

## Testing
- `dotnet build Client/RecM.Client.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfe0a809083268a8e5e6dc3f9e350