### PR TITLE
Return null when recording load fails

### DIFF
--- a/Shared/Recording.cs
+++ b/Shared/Recording.cs
@@ -1102,7 +1102,7 @@ namespace RecM
                         Main.Instance.DetachTick(RecordingCheckerThread);
                         _isPlaybackCheckerAttached = false;
                     }
-                    return;
+                    return null;
                 }
 
                 // Save the player's last position only if the last recording has stopped playing or the last location hasn't been stored


### PR DESCRIPTION
## Summary
- return `null` from `PlayRecording` when the vehicle recording fails to load so the method still satisfies its `Task<PlaybackSession>` signature

## Testing
- `dotnet build RecM.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfe0a2470832692eacbcbd735be10