### PR TITLE
Replace subtitle clear call with supported native

### DIFF
--- a/Shared/Recording.cs
+++ b/Shared/Recording.cs
@@ -544,7 +544,7 @@ namespace RecM
             if (subtitleLines.Count > 0)
                 Screen.ShowSubtitle(string.Join("\n", subtitleLines), 0);
             else
-                Screen.HideSubtitleThisFrame();
+                API.ClearPrints();
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- replace the unsupported Screen.HideSubtitleThisFrame call with API.ClearPrints when no subtitle text is present

## Testing
- dotnet build RecM.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfe08dca08326874524bede7bce58